### PR TITLE
Added fallback output to stderr instead of failing init.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "saschagrunert/mowl", branch = "master" }
 appveyor = { repository = "saschagrunert/mowl", branch = "master", service = "github" }
 
 [dependencies]
-failure = "0.1.2"
-log = { version="0.4.3", features=["std"] }
-term = "0.5.1"
-time = "0.1.40"
+failure = "0.1.7"
+log = { version="0.4.8", features=["std"] }
+term = "0.6.1"
+time = "0.1.41"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ extern crate time;
 
 use failure::Error;
 use log::{Level, LevelFilter, Log, Metadata, Record};
+use std::io::prelude::*;
 use term::{color::*, StderrTerminal};
 use time::now;
-use std::io::prelude::*;
 
 /// Initializes the global logger with a specific `max_log_level`.
 ///
@@ -42,7 +42,8 @@ pub fn init_with_level(log_level: LevelFilter) -> Result<(), Error> {
     log::set_boxed_logger(Box::new(Logger {
         level: log_level,
         enable_colors: true,
-    })).map(|()| log::set_max_level(log_level))?;
+    }))
+    .map(|()| log::set_max_level(log_level))?;
     Ok(())
 }
 
@@ -68,7 +69,8 @@ pub fn init_with_level_and_without_colors(log_level: LevelFilter) -> Result<(), 
     log::set_boxed_logger(Box::new(Logger {
         level: log_level,
         enable_colors: false,
-    })).map(|()| log::set_max_level(log_level))?;
+    }))
+    .map(|()| log::set_max_level(log_level))?;
     Ok(())
 }
 
@@ -161,9 +163,9 @@ enum LogSink {
 impl LogSink {
     fn new() -> Self {
         if let Some(term) = term::stderr() {
-             Self::Terminal(term)
+            Self::Terminal(term)
         } else {
-             Self::Fallback(std::io::stderr())
+            Self::Fallback(std::io::stderr())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,11 @@ use std::io::prelude::*;
 /// warn!("A warning");
 /// info!("A info message");
 /// # }
-/// ```
+///```
+///
+/// # Errors
+///
+/// An error is returned if a logger has already been set.
 pub fn init_with_level(log_level: LevelFilter) -> Result<(), Error> {
     log::set_boxed_logger(Box::new(Logger {
         level: log_level,
@@ -56,6 +60,10 @@ pub fn init_with_level(log_level: LevelFilter) -> Result<(), Error> {
 /// info!("A info message");
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// An error is returned if a logger has already been set.
 pub fn init_with_level_and_without_colors(log_level: LevelFilter) -> Result<(), Error> {
     log::set_boxed_logger(Box::new(Logger {
         level: log_level,
@@ -77,6 +85,10 @@ pub fn init_with_level_and_without_colors(log_level: LevelFilter) -> Result<(), 
 /// warn!("Warning");
 /// # }
 /// ```
+///
+/// # Errors
+///
+/// An error is returned if logger has already been initialized.
 pub fn init() -> Result<(), Error> {
     init_with_level(LevelFilter::Trace)
 }
@@ -170,7 +182,7 @@ impl LogSink {
     }
 }
 
-/// Implement Write for LogSink by forwarding to the underlying Writers
+/// Implement Write for `LogSink` by forwarding to the underlying Writers
 impl std::io::Write for LogSink {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {


### PR DESCRIPTION
Currently, initialization of the logger fails if a terminal cannot be opened.
In my opinion logging should not be a point of failure for any application, so I added a fallback solution that writes directly to stderr as discussed in https://github.com/Stebalien/term/issues/57.

Also ran clippy, rustfmt & updated dependencies (except for time).