### PR TITLE
updated time printing for current time crate (#2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "saschagrunert/mowl", branch = "master" }
 appveyor = { repository = "saschagrunert/mowl", branch = "master", service = "github" }
 
 [dependencies]
-failure = "0.1.7"
-log = { version="0.4.8", features=["std"] }
-term = "0.6.1"
-time = "0.1.41"
+failure = "0.1.8"
+log = { version = "0.4.14", features = ["std"] }
+term = "0.7.0"
+time = "0.2.25"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use failure::Error;
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::io::prelude::*;
 use term::{color::*, StderrTerminal};
-use time::now;
+use time::{Format, OffsetDateTime};
 
 /// Initializes the global logger with a specific `max_log_level`.
 ///
@@ -124,7 +124,11 @@ impl Logger {
         if self.enable_colors {
             t.fg(BRIGHT_BLACK)?;
         }
-        write!(t, "[{}] ", now().rfc3339())?;
+        write!(
+            t,
+            "[{}] ",
+            OffsetDateTime::now_utc().lazy_format(Format::Rfc3339)
+        )?;
         if self.enable_colors {
             t.fg(BRIGHT_BLUE)?;
         }


### PR DESCRIPTION
Update to fix #2 by using `time::OffsetDateTime::now() to replace obsolete time::now()` and fixing date/time formatting accordingly.

Please check that the new time format is correct and if not fix as required.